### PR TITLE
pingcheck: allow interfaces that do not have a default route

### DIFF
--- a/main.h
+++ b/main.h
@@ -22,7 +22,7 @@
 #define SCRIPTS_TIMEOUT		10 /* 10 sec */
 #define UBUS_TIMEOUT		3000 /* 3 sec */
 
-enum online_state { UNKNOWN, DOWN, NO_ROUTE, UP, OFFLINE, ONLINE };
+enum online_state { UNKNOWN, DOWN, UP_WITHOUT_DEFAULT_ROUTE, UP, OFFLINE, ONLINE };
 
 enum protocol { ICMP, TCP };
 

--- a/ping.c
+++ b/ping.c
@@ -110,9 +110,8 @@ bool ping_init(struct ping_intf* pi)
 		pi->state = DOWN;
 		return false;
 	} else if (ret == 1) {
-		LOG_INF("Interface '%s' no route", pi->name);
-		pi->state = NO_ROUTE;
-		return false;
+		LOG_INF("Interface '%s' has no default route but local one", pi->name);
+		pi->state = UP_WITHOUT_DEFAULT_ROUTE;
 	} else if (ret == 2) {
 		pi->state = UP;
 	}


### PR DESCRIPTION
This patch allows pingcheck to work with interfaces that do not have
a default route set. E.g. local tunnel interfaces like Wireguard can
now be monitored with pingcheck as well.

Signed-off-by: Thomas Huehn <thomas@net.t-labs.tu-berlin.de>