### PR TITLE
pingcheck: allow interfaces that do not have a default route

### DIFF
--- a/main.c
+++ b/main.c
@@ -51,7 +51,7 @@ const char* get_status_str(enum online_state state)
 	switch (state) {
 		case UNKNOWN: return "UNKNOWN";
 		case DOWN: return "DOWN";
-		case NO_ROUTE: return "NO_ROUTE";
+		case UP_WITHOUT_DEFAULT_ROUTE: return "UP_WITHOUT_DEFAULT_ROUTE";
 		case UP: return "UP";
 		case OFFLINE: return "OFFLINE";
 		case ONLINE: return "ONLINE";


### PR DESCRIPTION
This patch allows pingcheck to work with interfaces that do not have
a default route set. E.g. local tunnel interfaces like Wireguard can
now be monitored with pingcheck as well.

v2: fix remaining compile error with proper NO_ROUTE replacement  

Signed-off-by: Thomas Huehn <thomas@net.t-labs.tu-berlin.de>