### PR TITLE
allow for icmp reply to arrive on different interface then the sending one

### DIFF
--- a/main.c
+++ b/main.c
@@ -118,6 +118,19 @@ void notify_interface(const char* interface, const char* action)
 	}
 }
 
+struct ping_intf* get_interface_by_fd(int fd)
+{
+	struct ping_intf* pi = NULL;
+	/* find interface in our list */
+	for (int i = 0; i < MAX_NUM_INTERFACES && intf[i].name[0]; i++) {
+		if (intf[i].ufd.fd == fd) {
+			pi = &intf[i];
+			break;
+		}
+	}
+	return pi;
+}
+
 /* also called from ubus server_status */
 struct ping_intf* get_interface(const char* interface)
 {

--- a/main.h
+++ b/main.h
@@ -75,7 +75,7 @@ long timespec_diff_ms(struct timespec start, struct timespec end);
 // icmp.c
 int icmp_init(const char* ifname);
 bool icmp_echo_send(int fd, int dst, int cnt);
-bool icmp_echo_receive(int fd);
+int icmp_echo_receive(int fd);
 
 // tcp.c
 int tcp_connect(const char* ifname, int dst, int port);
@@ -105,6 +105,7 @@ void scripts_finish(void);
 
 // main.c
 void notify_interface(const char* interface, const char* action);
+struct ping_intf* get_interface_by_fd(int fd);
 struct ping_intf* get_interface(const char* interface);
 const char* get_status_str(enum online_state state);
 enum online_state get_global_status();


### PR DESCRIPTION
### Problem:
device has connectivity via wlan0 and eth0 in the same network (same ip network):
  - icmp replies arrive only on one interface (probably the faster one).
  - it is not always the same interface (can be either one)

### Solution:
- change icmp message id to include fd number of interface along the pid
- check if fd matches the receiving, if not look for an interface with matching fd and process the reply for this interface
