### PR TITLE
Fix build with kernel 5.15 and musl

### DIFF
--- a/icmp.c
+++ b/icmp.c
@@ -14,10 +14,11 @@
  */
 #include "main.h"
 #include <err.h>
+/* keep libc includes before linux headers for musl compatibility */
+#include <netinet/in.h>
 #include <linux/icmp.h>
 #include <linux/ip.h>
 #include <linux/if.h>
-#include <netinet/in.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>


### PR DESCRIPTION
Playing with kernel 5.15 I got redefinition errors:
```
make[2]: Entering directory '/openwrt/feeds/packages/net/pingcheck'
touch /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/.prepared_1fa17b23511e84f6c0eae108633ff31f_6664517399ebbbc92a37c5bb081b5c53_check
. /openwrt/include/shell.sh; xzcat /openwrt/dl/pingcheck-2021-02-22.tar.xz | tar -C /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/.. -xf -
[ ! -d ./src/ ] || cp -fpR ./src/. /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22
touch /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/.prepared_1fa17b23511e84f6c0eae108633ff31f_6664517399ebbbc92a37c5bb081b5c53
rm -f /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/.configured_*
rm -f /openwrt/staging_dir/target-aarch64_cortex-a53_musl/stamp/.pingcheck_installed
(cd /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/./; if [ -x ./configure ]; then find /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/ -name config.guess | xargs -r chmod u+w; find /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/ -name config.guess | xargs -r -n1 cp --remove-destination /openwrt/scripts/config.guess; find /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/ -name config.sub | xargs -r chmod u+w; find /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/ -name config.sub | xargs -r -n1 cp --remove-destination /openwrt/scripts/config.sub; AR="aarch64-openwrt-linux-musl-gcc-ar" AS="aarch64-openwrt-linux-musl-gcc -c -Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22=pingcheck-2021-02-22 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro" LD=aarch64-openwrt-linux-musl-ld NM="aarch64-openwrt-linux-musl-gcc-nm" CC="aarch64-openwrt-linux-musl-gcc" GCC="aarch64-openwrt-linux-musl-gcc" CXX="aarch64-openwrt-linux-musl-g++" RANLIB="aarch64-openwrt-linux-musl-gcc-ranlib" STRIP=aarch64-openwrt-linux-musl-strip OBJCOPY=aarch64-openwrt-linux-musl-objcopy OBJDUMP=aarch64-openwrt-linux-musl-objdump SIZE=aarch64-openwrt-linux-musl-size CFLAGS="-Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22=pingcheck-2021-02-22 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro " CXXFLAGS="-Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22=pingcheck-2021-02-22 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro " CPPFLAGS="-I/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/usr/include -I/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/fortify -I/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include " LDFLAGS="-L/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/usr/lib -L/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/lib -znow -zrelro "   ./configure --target=aarch64-openwrt-linux --host=aarch64-openwrt-linux --build=x86_64-pc-linux-gnu --program-prefix="" --program-suffix="" --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/lib --sysconfdir=/etc --datadir=/usr/share --localstatedir=/var --mandir=/usr/man --infodir=/usr/info --disable-nls  ; fi; )
touch /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/.configured_68b329da9893e34099c7d8ad5cb9c940
rm -f /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/.built
touch /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/.built_check
CFLAGS="-Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22=pingcheck-2021-02-22 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -I/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/usr/include -I/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/fortify -I/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include " CXXFLAGS="-Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22=pingcheck-2021-02-22 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -I/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/usr/include -I/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/fortify -I/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include " LDFLAGS="-L/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/usr/lib -L/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/lib -znow -zrelro " make  -C /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/. AR="aarch64-openwrt-linux-musl-gcc-ar" AS="aarch64-openwrt-linux-musl-gcc -c -Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -fmacro-prefix-map=/openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22=pingcheck-2021-02-22 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro" LD=aarch64-openwrt-linux-musl-ld NM="aarch64-openwrt-linux-musl-gcc-nm" CC="aarch64-openwrt-linux-musl-gcc" GCC="aarch64-openwrt-linux-musl-gcc" CXX="aarch64-openwrt-linux-musl-g++" RANLIB="aarch64-openwrt-linux-musl-gcc-ranlib" STRIP=aarch64-openwrt-linux-musl-strip OBJCOPY=aarch64-openwrt-linux-musl-objcopy OBJDUMP=aarch64-openwrt-linux-musl-objdump SIZE=aarch64-openwrt-linux-musl-size CROSS="aarch64-openwrt-linux-musl-" ARCH="aarch64" ;
make[3]: Entering directory '/openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22'
  DIR     build
  CC      main.c
  CC      icmp.c
In file included from icmp.c:20:
/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/netinet/in.h:23:8: error: redefinition of 'struct in6_addr'
   23 | struct in6_addr {
      |        ^~~~~~~~
In file included from /openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/linux/icmp.h:24,
                 from icmp.c:17:
/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/linux/in6.h:33:8: note: originally defined here
   33 | struct in6_addr {
      |        ^~~~~~~~
In file included from icmp.c:20:
/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/netinet/in.h:34:8: error: redefinition of 'struct sockaddr_in6'
   34 | struct sockaddr_in6 {
      |        ^~~~~~~~~~~~
In file included from /openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/linux/icmp.h:24,
                 from icmp.c:17:
/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/linux/in6.h:50:8: note: originally defined here
   50 | struct sockaddr_in6 {
      |        ^~~~~~~~~~~~
In file included from icmp.c:20:
/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/netinet/in.h:42:8: error: redefinition of 'struct ipv6_mreq'
   42 | struct ipv6_mreq {
      |        ^~~~~~~~~
In file included from /openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/linux/icmp.h:24,
                 from icmp.c:17:
/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/include/linux/in6.h:60:8: note: originally defined here
   60 | struct ipv6_mreq {
      |        ^~~~~~~~~
make[3]: *** [Makefile.default:69: build/icmp.o] Error 1
make[3]: Leaving directory '/openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22'
make[2]: *** [Makefile:64: /openwrt/build_dir/target-aarch64_cortex-a53_musl/pingcheck-2021-02-22/.built] Error 2
make[2]: Leaving directory '/openwrt/feeds/packages/net/pingcheck'
time: package/feeds/packages/pingcheck/compile#0.24#0.04#0.25
    ERROR: package/feeds/packages/pingcheck failed to build.
make[1]: *** [package/Makefile:116: package/feeds/packages/pingcheck/compile] Error 1
make[1]: Leaving directory '/openwrt'
make: *** [/openwrt/include/toplevel.mk:230: package/pingcheck/compile] Error 2
```

@robimarko [resolved](https://forum.openwrt.org/t/adding-openwrt-support-for-xiaomi-ax3600/55049/6076?u=xabolcs) a similar issue for [`libnetfilter-conntrack`](https://git.netfilter.org/libnetfilter_conntrack/commit/?id=21ee35dde73aec5eba35290587d479218c6dd824) package and gave a hint for me how to fix the same problem for `pingcheck`.

@robimarko, thanks for the commit message too! :wink: 